### PR TITLE
Smaller rgen apps

### DIFF
--- a/see/programs/rgen
+++ b/see/programs/rgen
@@ -65,7 +65,7 @@ end
     local archiveTable = { }
     for i = 1, #archiveBytes do
         local b = archiveBytes:sub(i, i):byte()
-        if b < 32 or b > 126 or b == 34 or b == 39 then
+        if b < 32 or b > 126 or b == 34 or b == 39 or b == 45 or b == 91 or b == 93 then
             archiveTable[i] = "\\" .. b
         else
             archiveTable[i] = string.char(b)

--- a/see/programs/rgen
+++ b/see/programs/rgen
@@ -64,7 +64,12 @@ end
 
     local archiveTable = { }
     for i = 1, #archiveBytes do
-        archiveTable[i] = "\\" .. archiveBytes:sub(i, i):byte()
+        local b = archiveBytes:sub(i, i):byte()
+        if b < 32 or b > 126 or b == 34 or b == 39 then
+            archiveTable[i] = "\\" .. b
+        else
+            archiveTable[i] = b:char()
+        end
     end
 
     local archiveConverted = table.concat(archiveTable)

--- a/see/programs/rgen
+++ b/see/programs/rgen
@@ -68,7 +68,7 @@ end
         if b < 32 or b > 126 or b == 34 or b == 39 then
             archiveTable[i] = "\\" .. b
         else
-            archiveTable[i] = b:char()
+            archiveTable[i] = string.char(b)
         end
     end
 


### PR DESCRIPTION
Fixed rgen so it only escapes non-printable characters, and " and '.

This should result in smaller code files from rgen.
