### PR TITLE
Allow == operator for Strings

### DIFF
--- a/see/lib/see/base/String.lua
+++ b/see/lib/see/base/String.lua
@@ -63,6 +63,10 @@ function String:init(...)
     end
 end
 
+function String:opEq(other)
+    return self:equals(other) 
+end
+
 function String:opIndex(index)
     if typeof(index) == "number" then
         return self.charArray[index]


### PR DESCRIPTION
Added String:opEq

This should work, right? I'm getting tired of typing stringVariable:equals(otherStringVariable)
